### PR TITLE
Fixed compatibility with 2021.12.x and updated descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 This is a `Local Push` integration for Philips airpurifiers.
 Currently only encrypted-CoAP is implemented.
 
-## BREAKING CHANGE:
-
-Change of platform name from philips_airpurifier to philips_airpurifier_coap to allow parallel operation of http custom component
+The repository is a fork of ``https://github.com/betaboon/` which I had to create because the original repository is no longer maintained.
 
 ## Install:
 
-Add `https://github.com/betaboon/philips-airpurifier.git` as custom-repository in [HACS](https://hacs.xyz/docs/faq/custom_repositories/)
+Add `https://github.com/rkuralev/philips-airpurifier.git` as custom-repository in [HACS](https://hacs.xyz/docs/faq/custom_repositories/)
 
 
 ## Setup:
@@ -81,7 +79,7 @@ To aquire those information please follow these steps:
 ### Prepare the environment
 
 ```sh
-git clone https://github.com/betaboon/philips-airpurifier.git
+git clone https://github.com/rkuralev/philips-airpurifier.git
 cd philips-airpurifier
 source aioairctrl-shell.sh
 ```

--- a/custom_components/philips_airpurifier_coap/fan.py
+++ b/custom_components/philips_airpurifier_coap/fan.py
@@ -380,7 +380,7 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
             await self._client.set_control_values(data=status_pattern)
 
     @property
-    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+    def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
         def append(
             attributes: dict,
             key: str,

--- a/custom_components/philips_airpurifier_coap/manifest.json
+++ b/custom_components/philips_airpurifier_coap/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "philips_airpurifier_coap",
   "name": "Philips AirPurifier (with CoAP)",
-  "version": "0.7.0",
-  "documentation": "https://github.com/betaboon/philips-airpurifier-coap",
+  "version": "0.7.1",
+  "documentation": "https://github.com/rkuralev/philips-airpurifier-coap",
   "dependencies": [],
-  "codeowners": ["@betaboon"],
+  "codeowners": ["@rkuralev"],
   "requirements": [
     "aioairctrl @ git+https://github.com/betaboon/aioairctrl@v0.2.1"
   ]


### PR DESCRIPTION
As the original repository is no longer maintained but I still use the integration and want to update my HA to 2021.12.5, I had to fork the repo and incorporate the suggested [here](https://github.com/betaboon/philips-airpurifier-coap/pull/65) change to make it work properly