### PR TITLE
Turn on display backlight when setting up

### DIFF
--- a/custom_components/philips_airpurifier_coap/fan.py
+++ b/custom_components/philips_airpurifier_coap/fan.py
@@ -302,6 +302,7 @@ class PhilipsGenericCoAPFanBase(PhilipsGenericFan):
         self._client = await CoAPClient.create(self._host)
         self._observer_task = None
         try:
+            await self._client.set_control_value(PHILIPS_DISPLAY_BACKLIGHT, "1")
             status = await self._client.get_status()
             device_id = status[PHILIPS_DEVICE_ID]
             self._unique_id = f"{self._model}-{device_id}"


### PR DESCRIPTION
After adding this custom component, HA was telling me `Setup of fan platform philips-airpurifier-coap is taking over 10 seconds.` and it did not set up successfully ever. It turns out, my device is not answering to `get_status()` calls, only if its state changes. So every time I restarted HA I had to go there and press a button on it, so it will send a status message.
This change sends a message to the device to turn on its backlight and it is successfully set up every time.

@rkuralev Now that I have your attention, would you mind turning on issues for the repository? I have a few ideas I would like to discuss.